### PR TITLE
Fix RemoveEventListener issue

### DIFF
--- a/src/CefWing/CefRenderApp/RenderDelegates/CefViewClient.cpp
+++ b/src/CefWing/CefRenderApp/RenderDelegates/CefViewClient.cpp
@@ -363,8 +363,10 @@ CefViewClient::RemoveEventListener(const CefString& name, const EventListener& l
   if (itListenerList != eventListenerListMap_.end()) {
     EventListenerList& eventListenerList = itListenerList->second;
     for (auto itListener = eventListenerList.begin(); itListener != eventListenerList.end(); itListener++) {
-      if (itListener->callback_->IsSame(listener.callback_))
+      if (itListener->callback_->IsSame(listener.callback_)) {
         eventListenerList.erase(itListener);
+        break;
+      }
     }
   }
 }


### PR DESCRIPTION
修复 `CefViewClient::RemoveEventListener` 中在迭代中调用 `erase` 导致的 `cannot increment value-initialized list iterator` 问题

复现：
![image](https://user-images.githubusercontent.com/3633972/190613265-cc147680-2a36-4e59-8841-a50222dae528.png)

在 tutorial.in.html 中的 `onInvokeMethodClicked` 方法中添加 `CallBridge.removeEventListener` 的调用：

![image](https://user-images.githubusercontent.com/3633972/190613494-4065f294-eb49-4695-8f6e-c1cbc012e6e4.png)


